### PR TITLE
Support non HTTP JWT validation

### DIFF
--- a/auth0.go
+++ b/auth0.go
@@ -185,3 +185,12 @@ func (v *JWTValidator) Claims(r *http.Request, token *jwt.JSONWebToken, values .
 	}
 	return token.Claims(key, values...)
 }
+
+// ClaimsFromToken unmarshall the claims of the provided token
+func (v *JWTValidator) ClaimsFromToken(token *jwt.JSONWebToken, values ...interface{}) error {
+	key, err := v.config.tokenSecretProvider.SecretFromToken(token)
+	if err != nil {
+		return err
+	}
+	return token.Claims(key, values...)
+}


### PR DESCRIPTION
In order to be able to validate tokens that are not coming from a `http.Request`, we need to provide additional interfaces to work with a `JSONWebToken` type.